### PR TITLE
Add python-django-extensions, python-pydot in lava-dev 'Recommends' list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,7 @@ Depends: build-essential, ca-certificates, devscripts, dpkg-dev,
  python-sphinx (>= 1.0.7+dfsg) | python3-sphinx, po-debconf,
  python-mocker, python-setuptools, python-versiontools,
  ${misc:Depends}
-Recommends: sbuild
+Recommends: sbuild, python-django-extensions, python-pydot
 Description: Linaro Automated Validation Architecture developer support
  LAVA is a continuous integration system for deploying operating
  systems onto physical and virtual hardware for running tests.


### PR DESCRIPTION
Once we have django-extensions support enabled via availability in lava-server this can be considered.

Depends on: https://review.linaro.org/#/c/5829/
