### PR TITLE
Minimal lxc version requirement / dependency >= 1:2.0.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,7 +58,7 @@ Architecture: all
 Section: metapackages
 Depends: lava-server, lava-server-doc, lava-dispatcher, lava-coordinator,
  lava-dev, lava-tool, lavapdu-client, ntp | ntpdate, tftpd-hpa,
- openssh-client, lxc, rsync, bridge-utils, ${misc:Depends}
+ openssh-client, lxc (>= 1:2.0.6), rsync, bridge-utils, ${misc:Depends}
 Recommends: lavapdu-daemon, linaro-image-tools, schroot
 Suggests: vmdebootstrap
 Description: Linaro Automated Validation Architecture metapackage


### PR DESCRIPTION
This solves issues seen with Debian lxc template.