### PR TITLE
Add a lintian override for lava-dev for newly added script.

### DIFF
--- a/debian/lava-dev.lintian-overrides
+++ b/debian/lava-dev.lintian-overrides
@@ -1,3 +1,3 @@
 lava-dev: python-script-but-no-python-dep usr/share/lava-server/render-template.py
 lava-dev: python-script-but-no-python-dep usr/share/lava-server/validate_devices.py
-
+lava-dev: python-script-but-no-python-dep usr/share/lava-server/download-test-suites-api.py


### PR DESCRIPTION
This is added for the python script download-test-suites-api.py